### PR TITLE
Abcd rework

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version='0.5.0',
     packages = find_namespace_packages(where = 'src'),
     package_dir={"": "src"},
+    python_requires='>=3.9',
     install_requires=['setuptools',
                       'schemdraw',
                       'numpy',
@@ -18,5 +19,6 @@ setup(
                       'pandas',
                       'scipy',
                       'pyqt5',
-                      'proplot==0.9.5']
+                      'proplot==0.9.5',
+                      'tensorwaves']
 )

--- a/src/parametricSynthesis/network_tools/component_ABCD.py
+++ b/src/parametricSynthesis/network_tools/component_ABCD.py
@@ -296,6 +296,11 @@ class DegenerateParametricInverterAmp:
         print("ALPHA = ", alpha)
         Jpa_val_s = 1 / omega_s_arr / Lprime / (1 - alpha) * np.sqrt(alpha)
         Jpa_val_i = 1 / np.abs(omega_i_arr) / Lprime / (1 - alpha) * np.sqrt(alpha)
+
+        Jpa_test = self.dw / self.Zcore / self.g_arr[1] / np.sqrt(self.g_arr[0]) * np.sqrt(self.g_arr[-1])
+        Jpa_val_s = Jpa_test
+        Jpa_val_i = Jpa_test
+
         inv_ABCD = np.array([[0*np.ones_like(omega_s_arr), 1j / np.conjugate(Jpa_val_s)*np.ones_like(omega_s_arr)],
                              [-1j * Jpa_val_i*np.ones_like(omega_s_arr), 0*np.ones_like(omega_s_arr)]])
         return np.moveaxis(inv_ABCD, -1,0)

--- a/src/parametricSynthesis/network_tools/component_ABCD.py
+++ b/src/parametricSynthesis/network_tools/component_ABCD.py
@@ -329,6 +329,10 @@ class DegenerateParametricInverterAmp:
         A3 = self.idler_inductor.ABCDshunt_function(omega_i_arr)
         return A1 @ A2 @ A3
 
+    def passive_abcd_function(self, omega_s_arr, omega_i_arr):
+        A1 = self.signal_inductor.ABCDshunt_function(omega_s_arr)
+        return A1
+
 @dataclass
 class Coupler:
     """
@@ -344,6 +348,8 @@ class Coupler:
     signal_or_idler_flag: str = 'signal'
     def abcd_function(self, omega_s, omega_i):
         pass
+    def passive_abcd_function(self, omega_s, omega_i):
+        return self.abcd_function(omega_s, omega_i)
 
 @dataclass
 class Resonator:
@@ -365,6 +371,9 @@ class Resonator:
         in the format Nx(2x2) where N is the number of frequency points
         '''
         pass
+
+    def passive_abcd_function(self, omega_s, omega_i):
+        return self.abcd_function(omega_s, omega_i)
 
     def compensate_for_couplers(self, c1: Coupler, c2: Coupler):
         '''
@@ -470,6 +479,10 @@ class CoreResonator:
         return (self.cap_s_el.ABCDshunt_function(omega_s_arr) @
                 self.inv_el.abcd_function(omega_s_arr, omega_i_arr) @
                 self.cap_i_el.ABCDshunt_function(omega_i_arr))
+
+    def passive_abcd_function(self, omega_s_arr, omega_i_arr):
+        return (self.cap_s_el.ABCDshunt_function(omega_s_arr) @
+                self.inv_el.passive_abcd_function(omega_s_arr, omega_i_arr))
 
     def add_to_drawing(self, d, l = 2):
         '''

--- a/src/parametricSynthesis/network_tools/component_ABCD.py
+++ b/src/parametricSynthesis/network_tools/component_ABCD.py
@@ -3,7 +3,9 @@ import sympy as sp
 import numpy as np
 from IPython.display import display
 from typing import Union
-
+from skrf.circuit import Circuit
+from skrf.network import Network
+from tqdm import tqdm
 '''
 we need classes for each circuit element, in particular, functions that can
 leverage sympy to give symbolic scattering information would be very helpful
@@ -17,7 +19,7 @@ def z_to_input_impedance(z: Union[sp.Matrix, np.array], Z0: Union[sp.Symbol, flo
     Zin = (Z11 + Z12 / Z0 + Z21 * Z0 + Z22)
     return Zin
 
-def abcd_to_s(abcd: Union[sp.Matrix, np.array], Z0: Union[sp.Symbol, float], num=False):
+def abcd_to_s(abcd: Union[sp.Matrix, np.array], Z0: Union[sp.Symbol, float], num=True):
     A = abcd[0, 0]
     B = abcd[0, 1]
     C = abcd[1, 0]
@@ -37,7 +39,7 @@ def abcd_to_s(abcd: Union[sp.Matrix, np.array], Z0: Union[sp.Symbol, float], num
     return Smtx
 
 
-def abcd_to_z(abcd: Union[sp.Matrix, np.array], num=False):
+def abcd_to_z(abcd: Union[sp.Matrix, np.array], num=True):
     A = abcd[0, 0]
     B = abcd[0, 1]
     C = abcd[1, 0]
@@ -66,7 +68,19 @@ def compress_abcd_array(ABCD_mtxs: list, simplify=False, mid_simplify_rules=[], 
         if debug:
             display(total_ABCD)
     return total_ABCD
+def compress_abcd_numerical(ABCD_list: list):
+    total_ABCD = np.tile(np.eye(2), (ABCD_list[0].shape[0],1,1)) #ABCD matrix at every index
+    print("compressing ABCD matrices...")
+    for i, el_ABCD in enumerate(tqdm(ABCD_list)):
+        total_ABCD = np.matmul(total_ABCD, el_ABCD)
+    return total_ABCD
 
+def cap_to_tline_length_mod_factor(cap,
+                                   z0,
+                                   omega0):
+    length_factor = (1-z0*omega0*cap*2/np.pi)
+    print("compensating z = ", z0, "tline with cap = ", cap, "length factor = ", length_factor)
+    return length_factor
 
 @dataclass
 class Resistor:
@@ -97,13 +111,21 @@ class Capacitor:
         return 1 / (sp.I * self.symbol * self.omega_symbol)
 
     def impedance_function(self, omega):
-        return sp.lambdify(omega, self.impedance_symbolic().subs(self.symbol, self.val))
+        return sp.lambdify(self.omega_symbol, self.impedance_symbolic().subs(self.symbol, self.val))(omega)
 
     def ABCDseries(self):
         return sp.Matrix([[1, self.impedance_symbolic()], [0, 1]])
 
     def ABCDshunt(self):
         return sp.Matrix([[1, 0], [1 / self.impedance_symbolic(), 1]])
+
+    def ABCDseries_function(self, omega):
+        return np.moveaxis(np.array([[1*np.ones_like(omega), self.impedance_function(omega)],
+                                     [0*np.ones_like(omega), 1*np.ones_like(omega)]]),-1,0)
+
+    def ABCDshunt_function(self, omega):
+        return np.moveaxis(np.array([[1*np.ones_like(omega), 0*np.ones_like(omega)],
+                                     [1 / self.impedance_function(omega), 1*np.ones_like(omega)]]),-1,0)
 
 
 @dataclass
@@ -116,7 +138,7 @@ class Inductor:
         return (sp.I * self.symbol * self.omega_symbol)
 
     def impedance_function(self, omega):
-        return sp.lambdify(omega, self.impedance_symbolic().subs(self.symbol, self.val))
+        return sp.lambdify(self.omega_symbol, self.impedance_symbolic().subs(self.symbol, self.val))(omega)
 
     def ABCDseries(self):
         return sp.Matrix([[1, self.impedance_symbolic()], [0, 1]])
@@ -124,9 +146,16 @@ class Inductor:
     def ABCDshunt(self):
         return sp.Matrix([[1, 0], [1 / self.impedance_symbolic(), 1]])
 
+    def ABCDseries_function(self, omega):
+        return np.array([[1*np.ones_like(omega), self.impedance_function(omega)], [0*np.ones_like(omega), 1*np.ones_like(omega)]])
+
+    def ABCDshunt_function(self, omega):
+        return np.moveaxis(np.array([[1*np.ones_like(omega), 0*np.ones_like(omega)],
+                         [1 / self.impedance_function(omega), 1*np.ones_like(omega)]]), -1,0)
+
 
 @dataclass
-class Tline:
+class Tline_short:
     omega_symbol: sp.Symbol
     Z_symbol: sp.Symbol
     theta_symbol: sp.Symbol
@@ -136,7 +165,73 @@ class Tline:
     theta_val: float
     omega0_val: float
 
-    def abcd_series(self, use_approx=False):
+    def short_impedance_symbolic(self, use_approx = False):
+        z0 = self.Z_symbol
+        bl = self.theta_symbol * self.omega_symbol / self.omega0_symbol
+
+        if use_approx == False:
+            cotan = sp.cot(bl)
+        else:
+            cotan = sp.series(sp.cot(bl), self.omega_symbol, x0=self.omega0_symbol, n=4).removeO()
+
+        return 1/(-sp.I * cotan / z0)
+    def open_impedance_symbolic(self, use_approx = False):
+        z0 = self.Z_symbol
+        bl = self.theta_symbol * self.omega_symbol / self.omega0_symbol
+
+        if use_approx == False:
+            tan = sp.tan(bl)
+        else:
+            tan = sp.series(sp.tan(bl), self.omega_symbol, x0=self.omega0_symbol, n=4).removeO()
+
+        return 1/(sp.I * tan / z0)
+    def impedance_function(self, use_approx = False):
+        return sp.lambdify(self.omega_symbol,
+                           self.short_impedance_symbolic(use_approx=use_approx).subs([
+                               (self.Z_symbol, self.Zval),
+                               (self.theta_symbol, self.theta_val),
+                               (self.omega0_symbol, self.omega0_val)]))
+
+    def ABCDshunt(self, use_approx=False):
+        return np.array([[1, 0], [1/self.short_impedance_symbolic(use_approx=use_approx), 1]])
+
+    def ABCDshunt_function(self, omega_arr):
+        return np.moveaxis(np.array([[1*np.ones_like(omega_arr), 0*np.ones_like(omega_arr)],
+                          [1/self.impedance_function()(omega_arr), 1*np.ones_like(omega_arr)]]),
+                           -1,0)
+
+
+@dataclass
+class Tline_open:
+    omega_symbol: sp.Symbol
+    Z_symbol: sp.Symbol
+    theta_symbol: sp.Symbol
+    omega0_symbol: sp.Symbol
+
+    Zval: float
+    theta_val: float
+    omega0_val: float
+
+    def impedance_symbolic(self, use_approx = False):
+        z0 = self.Z_symbol
+        bl = self.theta_symbol * self.omega_symbol / self.omega0_symbol
+
+        if use_approx == False:
+            tan = sp.tan(bl)
+        else:
+            tan = sp.series(sp.tan(bl), self.omega_symbol, x0=self.omega0_symbol, n=4).removeO()
+
+        return 1/(sp.I * tan / z0)
+    def impedance_function(self, use_approx = False):
+        return sp.lambdify(self.omega_symbol,
+                           self.impedance_symbolic(use_approx=use_approx).subs([
+                                                                                (self.Z_symbol, self.Zval),
+                                                                                (self.theta_symbol, self.theta_val),
+                                                                                (self.omega0_symbol, self.omega0_val)])
+                           )
+
+
+    def ABCDseries(self, use_approx=False):
         z0 = self.Z_symbol
         bl = self.theta_symbol * self.omega_symbol / self.omega0_symbol
         if use_approx == False:
@@ -148,7 +243,7 @@ class Tline:
 
         return sp.Matrix([[cos, sp.I * z0 * sin], [sp.I * 1 / z0 * sin, cos]])
 
-    def abcd_shunt_terminated(self, Zl, use_approx=False):
+    def ABCDshunt_terminated(self, Zl, use_approx=False):
         z0 = self.Z_symbol
         bl = self.theta_symbol * self.omega_symbol / self.omega0_symbol
 
@@ -159,28 +254,20 @@ class Tline:
 
         return sp.Matrix([[1, 0], [1 / z0 * ((z0 + sp.I * Zl * tan) / (Zl + sp.I * z0 * tan)), 1]])
 
-    def abcd_shunt_open(self, use_approx=False):
-        z0 = self.Z_symbol
-        bl = self.theta_symbol * self.omega_symbol / self.omega0_symbol
+    def ABCDshunt(self, use_approx=False):
 
-        if use_approx == False:
-            tan = sp.tan(bl)
-        else:
-            tan = sp.series(sp.tan(bl), self.omega_symbol, x0=self.omega0_symbol, n=4).removeO()
+        return sp.Matrix([[1, 0], [1/self.impedance_symbolic(use_approx=use_approx), 1]])
 
-        return sp.Matrix([[1, 0], [sp.I * tan / z0, 1]])
+    def ABCDshunt_function(self, omega_arr):
+        return np.moveaxis(np.array([[1*np.ones_like(omega_arr), 0*np.ones_like(omega_arr)],
+                          [1/self.impedance_function(omega_arr), 1*np.ones_like(omega_arr)]]), -1,0)
 
-    def abcd_shunt_short(self, use_approx=False):
-        z0 = self.Z_symbol
-        bl = self.theta_symbol * self.omega_symbol / self.omega0_symbol
-
-        if use_approx == False:
-            cotan = sp.cot(bl)
-        else:
-            cotan = sp.series(sp.cot(bl), self.omega_symbol, x0=self.omega0_symbol, n=4).removeO()
-
-        return sp.Matrix([[1, 0], [-sp.I * cotan / z0, 1]])
-
+    def ABCDseries_function(self, omega_arr, use_approx = False):
+        return np.moveaxis(sp.lambdify(self.omega_symbol,
+                           self.ABCDseries(use_approx = use_approx).subs([
+                               (self.Z_symbol, self.Zval),
+                               (self.theta_symbol, self.theta_val),
+                               (self.omega0_symbol, self.omega0_val)]))(omega_arr), -1,0)
 
 @dataclass
 class DegenerateParametricInverterAmp:
@@ -188,43 +275,275 @@ class DegenerateParametricInverterAmp:
     omega1: sp.Symbol
     omega2: sp.Symbol
     L: sp.Symbol
+    Lval: float
     R_active: sp.Symbol
     Jpa_sym: sp.Symbol
+    power_G_db: float
+    g_arr: list
+    net_size: int
+    dw: float
 
     def __post_init__(self):
-        self.Zcore = self.omega0_val * self.L
+        self.Zcore = self.omega0_val * self.Lval
         # print(f"Network INGREDIENTS: dw = {self.dw}\nZcore = {self.Zcore}\ng_arr = {self.g_arr}\ng0 = {self.g_arr[0]}\ng1 = {self.g_arr[1]}\ngN+1 = {self.g_arr[-1]}")
-        self.signal_inductor = Inductor(self.omega1, self.L, self.L)
-        self.idler_inductor = Inductor(self.omega2, self.L, self.L)
+        self.signal_inductor = Inductor(self.omega1, self.L, self.Lval)
+        self.idler_inductor = Inductor(self.omega2, self.L, self.Lval)
 
-    # def ABCD_series(self):
-    #   '''
-    #   This has to include both the series inductors and the inversion matrix
-    #   '''
-    #   inv_ABCD = sp.Matrix([[0, -sp.I*self.K1],[sp.I/sp.conjugate(self.K2), 0]])
-    #   return self.signal_inductor.ABCDseries()*inv_ABCD*self.idler_inductor.ABCDseries()
+    def abcd_inverter_shunt(self, omega_s_arr, omega_i_arr):
 
-    def abcd_signal_inductor_shunt(self):
-        return self.signal_inductor.ABCDshunt()
+        alpha = self.alpha_val_from_matching_params(10**self.power_G_db/10, self.dw, self.g_arr)
+        Lprime = self.Lval * (1 - alpha)
+        print("ALPHA = ", alpha)
+        Jpa_val_s = 1 / omega_s_arr / Lprime / (1 - alpha) * np.sqrt(alpha)
+        Jpa_val_i = 1 / np.abs(omega_i_arr) / Lprime / (1 - alpha) * np.sqrt(alpha)
+        inv_ABCD = np.array([[0*np.ones_like(omega_s_arr), 1j / np.conjugate(Jpa_val_s)*np.ones_like(omega_s_arr)],
+                             [-1j * Jpa_val_i*np.ones_like(omega_s_arr), 0*np.ones_like(omega_s_arr)]])
+        return np.moveaxis(inv_ABCD, -1,0)
 
-    def abcd_inverter_shunt(self):
-
-        inv_ABCD = sp.Matrix([[0, sp.I / self.Jpa_sym], [-sp.I * self.Jpa_sym, 0]])
-        return inv_ABCD
-
-    def abcd_idler_inductor_shunt(self):
-        return self.idler_inductor.ABCDshunt()
-
-    def abcd_pumpistor(self):
-        inv_ABCD = sp.Matrix([[1, 0], [1 / self.R_active, 0]])
-        return self.signal_inductor.ABCDshunt() * inv_ABCD
-
-    def dm(self):
-        return 2 * sp.sqrt(self.L * self.L * self.alpha)
+    # def dm(self):
+    #     return 2 * sp.sqrt(self.L * self.L * self.alpha)
 
     def alpha_val_from_matching_params(self, G, frac_bw, g_arr):
         if np.size(g_arr) % 2 == 0:
             return (np.sqrt(G) - 1) / (np.sqrt(G) + 1) * (frac_bw / g_arr[1]) ** 2 * g_arr[-1] ** 2
         else:
             return (np.sqrt(G) - 1) / (np.sqrt(G) + 1) * (frac_bw / g_arr[1]) ** 2 / g_arr[-1] ** 2
+
+    def abcd_function(self, omega_s_arr, omega_i_arr):
+        A1 = self.signal_inductor.ABCDshunt_function(omega_s_arr)
+        A2 = self.abcd_inverter_shunt(omega_s_arr, omega_i_arr)
+        A3 = self.idler_inductor.ABCDshunt_function(omega_i_arr)
+        return A1 @ A2 @ A3
+
+@dataclass
+class Coupler:
+    """
+    class containing all parameters of any given coupler in the filter network, whether it's lumped, tline, etc.
+    """
+    n: int
+    omega_sym: sp.Symbol
+    omega0_sym: sp.Symbol
+    omega0_val: float
+    j_val: float
+    cap_comp_val: float = 0
+    ind_comp_val: float = 0
+    signal_or_idler_flag: str = 'signal'
+    def abcd_function(self, omega_s, omega_i):
+        pass
+
+@dataclass
+class Resonator:
+    """
+    class containing all parameters of any given resonator in the filter network, whether it's lumped, tline, etc.
+    All the functions except the compensation function need to be overridden as they are placeholders for the subclasses
+    """
+    n: int
+    omega_sym: sp.Symbol
+    omega0_sym: sp.Symbol
+    omega0_val: float
+    z_sym: sp.Symbol
+    z_val: float
+    signal_or_idler_flag: str
+
+    def abcd_function(self, omega_s, omega_i):
+        '''
+        Function that returns the ABCD matrix as a function of frequency for a shunt resonator
+        in the format Nx(2x2) where N is the number of frequency points
+        '''
+        pass
+
+    def compensate_for_couplers(self, c1: Coupler, c2: Coupler):
+        '''
+        Function that compensates the resonator for the coupling capacitors according to their comp_cap_val
+        '''
+        pass
+
+@dataclass
+class LumpedResonator(Resonator):
+
+    def __post_init__(self):
+        """
+        Adds a lumped resonator to the network
+        :param n: location of the resonator in the network, this will be used to name the elements and assign the values
+        to variables
+        :param net_size: number of resonators in the network. This is actually unused in this function, but is used in
+        the lumped_res_compensated function
+        :param omega_sym: the symbol for the angular frequency
+        :param include_inductor: whether to include an inductor in the resonator. This is used for the first resonator
+        in the network, which has the parametric inverter element that includes the inductor
+        :param compensated: whether the capacitors in the resonator are compensated by coupling caps or not
+        :return:
+        """
+        self.ind_sym = sp.symbols("L" + str(self.n))
+        self.cap_sym = sp.symbols("C" + str(self.n))
+        self.ind_val = self.z_val / self.omega0_val
+        self.cap_val = 1 / (self.z_val * self.omega0_val)
+
+    def compensate_for_couplers(self, c1, c2):
+        print("compensating resonator ", self.n, "with caps ", c1.cap_comp_val, "and ", c2.cap_comp_val)
+        self.cap_val -= (c1.cap_comp_val+c2.cap_comp_val)
+
+    def synthesize(self):
+        self.ind_el = Inductor(self.omega_sym, self.ind_sym, self.ind_val)
+        self.cap_el = Capacitor(self.omega_sym, self.cap_sym, self.cap_val)
+
+    def abcd_function(self, omega_s_arr, omega_i_arr):
+        if self.signal_or_idler_flag == 'signal':
+            omega = omega_s_arr
+        else:
+            omega = omega_i_arr
+        return self.ind_el.ABCDshunt_function(omega) @ self.cap_el.ABCDshunt_function(omega)
+
+@dataclass
+class CoreResonator:
+    n: int
+    omega_s_sym: sp.Symbol
+    omega_i_sym: sp.Symbol
+    omega0_sym: sp.Symbol
+    omega0_val: float
+    z_sym: sp.Symbol
+    z_val: float
+    jpa_sym: sp.Symbol
+    power_G_db: float
+    g_arr: list
+    net_size: int
+    dw: float
+
+    def __post_init__(self):
+        self.ind_sym = sp.symbols("L" + str(self.n))
+        self.R_active_sym = sp.symbols("R" + str(self.n))
+        self.cap_s_sym = sp.symbols("Cs" + str(self.n))
+        self.cap_i_sym = sp.symbols("Ci" + str(self.n))
+        self.ind_val = self.z_val / self.omega0_val
+        # print("Inductor VALUE = ", self.ind_val)
+        self.cap_val = 1 / (self.z_val * self.omega0_val)
+        # print("Capacitor VALUE = ", self.cap_val)
+
+    def compensate_for_couplers(self, c1):
+        self.cap_val -= c1.cap_comp_val
+
+    def synthesize(self):
+        self.inv_el = DegenerateParametricInverterAmp(self.omega0_val,
+                                                      self.omega_s_sym,
+                                                      self.omega_i_sym,
+                                                      self.ind_sym,
+                                                      self.ind_val,
+                                                      self.R_active_sym,
+                                                      self.jpa_sym,
+                                                      self.power_G_db,
+                                                      self.g_arr,
+                                                      self.net_size,
+                                                      self.dw)
+
+        self.cap_s_el = Capacitor(self.omega_s_sym, self.cap_s_sym, self.cap_val)
+        self.cap_i_el = Capacitor(self.omega_i_sym, self.cap_i_sym, self.cap_val)
+
+    def abcd_function(self, omega_s_arr, omega_i_arr):
+        return (self.cap_s_el.ABCDshunt_function(omega_s_arr) @
+                self.inv_el.abcd_function(omega_s_arr, omega_i_arr) @
+                self.cap_i_el.ABCDshunt_function(omega_i_arr))
+
+@dataclass
+class TlineL4Resonator(Resonator):
+
+    def __post_init__(self):
+        """
+        Adds a lumped resonator to the network
+        :param n: location of the resonator in the network, this will be used to name the elements and assign the values
+        to variables
+        :param net_size: number of resonators in the network. This is actually unused in this function, but is used in
+        the lumped_res_compensated function
+        :param omega_sym: the symbol for the angular frequency
+        :param include_inductor: whether to include an inductor in the resonator. This is used for the first resonator
+        in the network, which has the parametric inverter element that includes the inductor
+        :param compensated: whether the capacitors in the resonator are compensated by coupling caps or not
+        :return:
+        """
+        self.theta_sym = sp.symbols("theta_" + str(self.n))
+        self.z_sym = sp.symbols("Zt_" + str(self.n))
+        self.theta_val = np.pi/2
+        self.z_tline = self.z_val*np.pi/4
+
+    def compensate_for_couplers(self, c1, c2):
+        self.theta_val *= cap_to_tline_length_mod_factor(c1.cap_comp_val+c2.cap_comp_val, self.z_tline, self.omega0_val)
+
+    def synthesize(self):
+        self.tline_el = Tline_short(self.omega_sym,
+                                    self.z_sym,
+                                    self.theta_sym,
+                                    self.omega0_sym,
+                                    self.z_tline,
+                                    self.theta_val,
+                                    self.omega0_val)
+
+    def abcd_function(self, omega_s_arr, omega_i_arr):
+        if self.signal_or_idler_flag == 'signal':
+            omega = omega_s_arr
+        else:
+            omega = omega_i_arr
+        return self.tline_el.ABCDshunt_function(omega)
+
+@dataclass
+class CapCoupler(Coupler):
+    def __post_init__(self):
+        self.cap_sym = sp.symbols("Cc_" + str(self.n))
+        self.cap_val = 1/self.omega0_val*self.j_val
+        self.cap_comp_val = self.cap_val
+
+    def compensate_end_capacitor(self, zl):
+        '''
+        two things need to happen here:
+
+        one: this capacitor's main value is divided by the sqrt of the mod factor,
+        this happens in regular synthesis just because the bounds have no
+        reactive part
+
+        two: the compensation value is bumped *up* by the sqrt of the mod factor compared to the base capacitance,
+        because we have to compensate the
+        only adjacent resonator more because it is the *only* adjacent resonator
+
+        zl is the load impedance (resistance) that we are terminating against
+        '''
+
+        mod_factor = (1 - zl ** 2 * self.j_val ** 2)
+        self.cap_comp_val = self.cap_val * np.sqrt(mod_factor)
+        self.cap_val = self.cap_val / np.sqrt(mod_factor)
+
+    def synthesize(self):
+        self.cap_el = Capacitor(self.omega_sym, self.cap_sym, self.cap_val)
+
+    def abcd_function(self, omega_s_arr, omega_i_arr):
+        if self.signal_or_idler_flag == 'signal':
+            omega = omega_s_arr
+        else:
+            omega = omega_i_arr
+        return self.cap_el.ABCDseries_function(omega)
+
+@dataclass
+class TlineCoupler(Coupler):
+
+    def __post_init__(self):
+        self.theta_sym = sp.symbols("theta_c_" + str(self.n))
+        self.z_sym = sp.symbols("Zt_c_" + str(self.n))
+        self.theta_val = sp.pi/2
+        self.z_tline = 1/self.j_val
+        self.tline_el = Tline_open(self.omega_sym,
+                                   self.z_sym,
+                                   self.theta_sym,
+                                   self.omega0_sym,
+                                   self.z_tline,
+                                   self.theta_val,
+                                   self.omega0_val)
+    def synthesize(self):
+        pass
+
+    def compensate_end_capacitor(self, zl):
+        pass
+    def abcd_function(self, omega_s_arr, omega_i_arr):
+        if self.signal_or_idler_flag == 'signal':
+            omega = omega_s_arr
+        else:
+            omega = omega_i_arr
+        return self.tline_el.ABCDseries_function(omega)
+
 

--- a/src/parametricSynthesis/network_tools/component_ABCD.py
+++ b/src/parametricSynthesis/network_tools/component_ABCD.py
@@ -471,17 +471,17 @@ class CoreResonator:
                 self.inv_el.abcd_function(omega_s_arr, omega_i_arr) @
                 self.cap_i_el.ABCDshunt_function(omega_i_arr))
 
-    def add_to_drawing(self, d, l = 1.5):
+    def add_to_drawing(self, d, l = 2):
         '''
         Adds the resonator to a drawing object from schemdraw going right from the port
         '''
-        d += elm.Inductor2().down().label(f"$L =$ {np.round(self.ind_val * 1e12, 1)} pH", loc='bottom')
-        d += elm.Line().right().length(l / 2)
+        d += elm.Inductor2().down().label(f"$L =$ {np.round(self.ind_val * 1e12, 1)} pH", loc='top')
+        d += elm.Line().right().length(l)
         d.pop()
         d += elm.Line().right().length(l)
         d.push()
-        d += elm.Capacitor().down().label(f"\n\n$C =$ {np.round(self.cap_val * 1e12, 3)} pF", loc='top')
-        d += elm.Line().left().length(l / 2)
+        d += elm.Capacitor().down().label(f"\n\n$C =$ {np.round(self.cap_val * 1e12, 3)} pF", loc='bottom')
+        d += elm.Line().left().length(l)
         d += elm.Ground()
         d.pop()
 
@@ -525,6 +525,13 @@ class TlineL4Resonator(Resonator):
             omega = omega_i_arr
         return self.tline_el.ABCDshunt_function(omega)
 
+    def add_to_drawing(self, d, l = 1.5):
+        d += elm.Coax().down().label(
+            r"$\theta=$" + f"{np.round(self.theta_val * 360 / 2 / np.pi, 2)} \n$Z_c=$ {np.round(self.z_tline, 1)} $\Omega$",
+            loc='top')
+        d += elm.Ground()
+        d.pop()
+
 @dataclass
 class CapCoupler(Coupler):
     def __post_init__(self):
@@ -561,6 +568,12 @@ class CapCoupler(Coupler):
             omega = omega_i_arr
         return self.cap_el.ABCDseries_function(omega)
 
+    def add_to_drawing(self, d, l = 1.5):
+        d += elm.Capacitor(
+            label=f"C = {np.round(self.cap_val * 1e12, 3)} pF").scale(
+            1).right()
+        d.push()
+
 @dataclass
 class TlineCoupler(Coupler):
 
@@ -590,7 +603,7 @@ class TlineCoupler(Coupler):
 
     def add_to_drawing(self, d , l = 1.5):
         d += elm.Coax(
-            label=f"$\lambda/4$\n$Z_c$ = {np.round(1 / self.z_tline, 1)} $\Omega$").scale(
+            label=f"$\lambda/4$\n$Z_c$ = {np.round(self.z_tline, 1)} $\Omega$").scale(
             1).right()
         d.push()
 

--- a/src/parametricSynthesis/network_tools/component_ABCD.py
+++ b/src/parametricSynthesis/network_tools/component_ABCD.py
@@ -6,6 +6,8 @@ from typing import Union
 from skrf.circuit import Circuit
 from skrf.network import Network
 from tqdm import tqdm
+import schemdraw
+import schemdraw.elements as elm
 '''
 we need classes for each circuit element, in particular, functions that can
 leverage sympy to give symbolic scattering information would be very helpful
@@ -406,6 +408,20 @@ class LumpedResonator(Resonator):
             omega = omega_i_arr
         return self.ind_el.ABCDshunt_function(omega) @ self.cap_el.ABCDshunt_function(omega)
 
+    def add_to_drawing(self, d, l = 1.5):
+        '''
+        Adds the resonator to a drawing object from schemdraw going right from the port
+        '''
+        d += elm.Inductor2().down().label(f"$L =$ {np.round(self.ind_val * 1e12, 1)} pH", loc='bottom')
+        d += elm.Line().right().length(l / 2)
+        d.pop()
+        d += elm.Line().right().length(l)
+        d.push()
+        d += elm.Capacitor().down().label(f"\n\n$C =$ {np.round(self.cap_val * 1e12, 3)} pF", loc='top')
+        d += elm.Line().left().length(l / 2)
+        d += elm.Ground()
+        d.pop()
+
 @dataclass
 class CoreResonator:
     n: int
@@ -454,6 +470,20 @@ class CoreResonator:
         return (self.cap_s_el.ABCDshunt_function(omega_s_arr) @
                 self.inv_el.abcd_function(omega_s_arr, omega_i_arr) @
                 self.cap_i_el.ABCDshunt_function(omega_i_arr))
+
+    def add_to_drawing(self, d, l = 1.5):
+        '''
+        Adds the resonator to a drawing object from schemdraw going right from the port
+        '''
+        d += elm.Inductor2().down().label(f"$L =$ {np.round(self.ind_val * 1e12, 1)} pH", loc='bottom')
+        d += elm.Line().right().length(l / 2)
+        d.pop()
+        d += elm.Line().right().length(l)
+        d.push()
+        d += elm.Capacitor().down().label(f"\n\n$C =$ {np.round(self.cap_val * 1e12, 3)} pF", loc='top')
+        d += elm.Line().left().length(l / 2)
+        d += elm.Ground()
+        d.pop()
 
 @dataclass
 class TlineL4Resonator(Resonator):
@@ -557,5 +587,11 @@ class TlineCoupler(Coupler):
         else:
             omega = omega_i_arr
         return self.tline_el.ABCDseries_function(omega)
+
+    def add_to_drawing(self, d , l = 1.5):
+        d += elm.Coax(
+            label=f"$\lambda/4$\n$Z_c$ = {np.round(1 / self.z_tline, 1)} $\Omega$").scale(
+            1).right()
+        d.push()
 
 

--- a/src/parametricSynthesis/network_tools/network_synthesis.py
+++ b/src/parametricSynthesis/network_tools/network_synthesis.py
@@ -383,6 +383,30 @@ class Network:
 
         return compress_abcd_numerical(self.ABCD_mtxs_vs_frequency) #omega_s just for length
 
+    def draw_circuit(self, l = 1.5):
+        with schemdraw.Drawing() as d:
+            d += elm.Ground()
+            d += elm.RBox(label="$Z_0$").up()
+            for el in self.circuit_elements[:len(self.circuit_elements)//2+1]:
+                el.add_to_drawing(d, l = l)
+        return d
+
+    def scattering_from_inv_core_factors(self, inv_corr_factors):
+        self.gen_net_by_type(self, self.resonator_types, self.coupler_types, inv_corr_factors)
+
+        f_p_GHz = self.omega0_val/1e9/2/np.pi*2
+        f_arr_GHz = self.omega_0_val/1e9/2/np.pi+np.linspace(-self.dw/2, self.dw/2, 1001)
+
+        self.omega_s_arr = 2 * np.pi * f_arr_GHz * 1e9
+        self.omega_i_arr = (2 * np.pi * f_arr_GHz * 1e9 - 2 * np.pi * f_p_GHz * 1e9)
+
+        self.Smtx_j0 = self.Smtx_func(self.omega_s_arr, self.omega_i_arr)
+    def optimize_inv_core_factors(self, omega_s, omega_i):
+        '''
+        This function optimizes inverter corrections using the network gain and fractional bandwidth, then
+        returns the optimized inverter correction factors
+        '''
+
     def Smtx_func(self, omega_s, omega_i):
         ABCD_mtx = np.moveaxis(self.total_ABCD_func(omega_s, omega_i), 0, -1)
         return abcd_to_s(ABCD_mtx, 50)

--- a/testing/NIST_015HighQ_network_calc.py
+++ b/testing/NIST_015HighQ_network_calc.py
@@ -30,10 +30,10 @@ Z_squid = w0 * L_squid
 # coupler_types = ['cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap']
 
 power_G_db = 20
-g_arr = prototype_gs(power_G_db, type = 'chebyshev', n = 5, r_db = 5)
-z_arr = np.array([Z_squid, Z_squid*4/np.pi, Z_squid*4/np.pi, Z_squid*4/np.pi, Z_squid*4/np.pi, 50], dtype=float)
-resonator_types = ['core', 'l4','l4','l4','l4']
-coupler_types = ['l4', 'l4', 'l4', 'l4','l4']
+g_arr = prototype_gs(power_G_db, type = 'chebyshev', n = 3, r_db = 5)
+z_arr = np.array([Z_squid, Z_squid*4/np.pi, Z_squid*4/np.pi, 50], dtype=float)
+resonator_types = ['core', 'l4','l4']
+coupler_types = ['l4', 'l4', 'l4']
 
 inv_corr_factors = [1,1,1,1,1]
 

--- a/testing/NIST_015HighQ_network_calc.py
+++ b/testing/NIST_015HighQ_network_calc.py
@@ -1,0 +1,72 @@
+from parametricSynthesis.network_tools.network_synthesis import (get_active_network_prototypes,
+                                                                 get_passive_network_prototypes,
+                                                                 calculate_network)
+from parametricSynthesis.network_tools.prototype_calc import prototype_gs
+import numpy as np
+import matplotlib.pyplot as plt
+
+from parametricSynthesis.network_tools.network_synthesis import (get_active_network_prototypes,
+                                                                 get_passive_network_prototypes,
+                                                                 calculate_network)
+from parametricSynthesis.network_tools.prototype_calc import prototype_gs
+import numpy as np
+import matplotlib.pyplot as plt
+from parametricSynthesis.network_tools.component_ABCD import abcd_to_s
+
+net_dict = {}
+active_network_prototypes = get_active_network_prototypes()
+passive_network_prototypes = get_passive_network_prototypes()
+f0 = 5e9
+w0 = 2 * np.pi * f0
+dw = 0.135
+# Z_squid = 25
+L_squid = 0.15e-9
+# L_squid = w0*Z_squid
+Z_squid = w0 * L_squid
+
+# g_arr = prototype_gs(20, type = 'chebyshev', n = 5, r_db = 1)
+# z_arr = np.array([0, 20*4/np.pi, 30*4/np.pi, 30*4/np.pi, 20*4/np.pi, 50], dtype=float)
+# resonator_types = ['core', 'l4', 'l4', 'l4', 'l4', 'l4', 'l4', 'l4', 'l4']
+# coupler_types = ['cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap']
+
+power_G_db = 20
+g_arr = prototype_gs(power_G_db, type = 'chebyshev', n = 3, r_db = 1)
+z_arr = np.array([Z_squid, 20, 30, 50], dtype=float)
+resonator_types = ['core', 'l4', 'l4', 'l4', 'l4']
+coupler_types = ['l4', 'l4', 'l4', 'l4', 'l4']
+
+tline_corr_factor = 1
+
+net = calculate_network(power_G_db, g_arr, z_arr, f0, dw, L_squid, printout=False, inv_corr_factor=tline_corr_factor)
+
+net.gen_net_by_type(resonator_types, coupler_types, draw=True)
+
+fig, ax = plt.subplots()
+ax.set_title('Gain by pump power and filter type')
+ax.set_title('Gain by pump power and filter type')
+ax.grid()
+
+f_arr_GHz = np.linspace(f0/1e9-1, f0/1e9+1, 10001)
+f_p_GHz = 2*f0/1e9
+
+# plt.figure()
+# f_test = 2*np.pi*f_arr_GHz*1e9
+# s_par_test = abcd_to_s(np.moveaxis(net.ABCD_methods[1](f_test,f_test), 0,-1), 50)
+# # plt.plot(f_test/1e9/2/np.pi,np.angle(s_par_test[0,0])*180/np.pi)
+# plt.plot(f_test/1e9/2/np.pi,20*np.log10(np.abs(s_par_test[0,0])))
+# plt.show()
+# breakpoint()
+fig = net.plot_scattering(f_arr_GHz,f_p_GHz,
+                        linestyle = 'solid',
+                        fig = fig,
+                        primary_color = 'b',
+                        label_prepend='pumped mutual ');
+
+# del_fig, del_ax = plt.subplots()
+# omega_arr = net.omega_plot_arr
+# del_arr = -np.gradient(np.unwrap(np.arctan2(net.Smtx_j0[0,0,:].imag, net.Smtx_j0[0,0,:].real)))/np.gradient(omega_arr)*1e9
+# del_ax.plot(omega_arr/2/np.pi, del_arr)
+# del_ax.grid()
+
+# plt.show()
+breakpoint()

--- a/testing/NIST_015HighQ_network_calc.py
+++ b/testing/NIST_015HighQ_network_calc.py
@@ -16,11 +16,11 @@ from parametricSynthesis.network_tools.component_ABCD import abcd_to_s
 net_dict = {}
 active_network_prototypes = get_active_network_prototypes()
 passive_network_prototypes = get_passive_network_prototypes()
-f0 = 5e9
+f0 = 6.5e9
 w0 = 2 * np.pi * f0
-dw = 0.135
+dw = 0.2
 # Z_squid = 25
-L_squid = 0.15e-9
+L_squid = 0.37e-9
 # L_squid = w0*Z_squid
 Z_squid = w0 * L_squid
 
@@ -30,16 +30,16 @@ Z_squid = w0 * L_squid
 # coupler_types = ['cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap']
 
 power_G_db = 20
-g_arr = prototype_gs(power_G_db, type = 'chebyshev', n = 3, r_db = 1)
-z_arr = np.array([Z_squid, 20, 30, 50], dtype=float)
-resonator_types = ['core', 'l4', 'l4', 'l4', 'l4']
-coupler_types = ['l4', 'l4', 'l4', 'l4', 'l4']
+g_arr = prototype_gs(power_G_db, type = 'chebyshev', n = 5, r_db = 1)
+z_arr = np.array([Z_squid, 15*4/np.pi, 15*4/np.pi, 15*4/np.pi, 15*4/np.pi, 50], dtype=float)
+resonator_types = ['core', 'l4','l4','l4','l4']
+coupler_types = ['cap', 'l4', 'cap', 'cap','l4']
 
-tline_corr_factor = 1
+inv_corr_factors = [1,1,1,1,1]
 
-net = calculate_network(power_G_db, g_arr, z_arr, f0, dw, L_squid, printout=False, inv_corr_factor=tline_corr_factor)
+net = calculate_network(power_G_db, g_arr, z_arr, f0, dw, L_squid, printout=False)
 
-net.gen_net_by_type(resonator_types, coupler_types, draw=True)
+net.gen_net_by_type(resonator_types, coupler_types, inv_corr_factors, draw=True)
 
 fig, ax = plt.subplots()
 ax.set_title('Gain by pump power and filter type')
@@ -47,7 +47,8 @@ ax.set_title('Gain by pump power and filter type')
 ax.grid()
 
 f_arr_GHz = np.linspace(f0/1e9-1, f0/1e9+1, 10001)
-f_p_GHz = 2*f0/1e9
+delta = 0e-3
+f_p_GHz = 2*f0/1e9-delta
 
 # plt.figure()
 # f_test = 2*np.pi*f_arr_GHz*1e9

--- a/testing/NIST_015HighQ_network_calc.py
+++ b/testing/NIST_015HighQ_network_calc.py
@@ -18,7 +18,7 @@ active_network_prototypes = get_active_network_prototypes()
 passive_network_prototypes = get_passive_network_prototypes()
 f0 = 6.5e9
 w0 = 2 * np.pi * f0
-dw = 0.2
+dw = 0.15
 # Z_squid = 25
 L_squid = 0.37e-9
 # L_squid = w0*Z_squid
@@ -30,10 +30,10 @@ Z_squid = w0 * L_squid
 # coupler_types = ['cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap', 'cap']
 
 power_G_db = 20
-g_arr = prototype_gs(power_G_db, type = 'chebyshev', n = 5, r_db = 1)
-z_arr = np.array([Z_squid, 15*4/np.pi, 15*4/np.pi, 15*4/np.pi, 15*4/np.pi, 50], dtype=float)
+g_arr = prototype_gs(power_G_db, type = 'chebyshev', n = 5, r_db = 5)
+z_arr = np.array([Z_squid, Z_squid*4/np.pi, Z_squid*4/np.pi, Z_squid*4/np.pi, Z_squid*4/np.pi, 50], dtype=float)
 resonator_types = ['core', 'l4','l4','l4','l4']
-coupler_types = ['cap', 'l4', 'cap', 'cap','l4']
+coupler_types = ['l4', 'l4', 'l4', 'l4','l4']
 
 inv_corr_factors = [1,1,1,1,1]
 
@@ -57,11 +57,13 @@ f_p_GHz = 2*f0/1e9-delta
 # plt.plot(f_test/1e9/2/np.pi,20*np.log10(np.abs(s_par_test[0,0])))
 # plt.show()
 # breakpoint()
+d = net.draw_circuit(l = 2)
 fig = net.plot_scattering(f_arr_GHz,f_p_GHz,
                         linestyle = 'solid',
                         fig = fig,
                         primary_color = 'b',
                         label_prepend='pumped mutual ');
+
 
 # del_fig, del_ax = plt.subplots()
 # omega_arr = net.omega_plot_arr
@@ -69,5 +71,5 @@ fig = net.plot_scattering(f_arr_GHz,f_p_GHz,
 # del_ax.plot(omega_arr/2/np.pi, del_arr)
 # del_ax.grid()
 
-# plt.show()
+plt.show()
 breakpoint()


### PR DESCRIPTION
This rips out just about all the guts of the network synthesis module and replaces them with better guts that don't require a bunch of exceptions and logic for creating ABCD matrices and drawings. It is also MUCH faster, and will work for tuning up 4+pole networks with mixed coupler types.